### PR TITLE
Pin Node.js version to 26.1.0 via volta

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "k35o <k8o@k8o.me>",
   "license": "MIT",
   "packageManager": "pnpm@10.33.3",
+  "volta": {
+    "node": "26.1.0"
+  },
   "scripts": {
     "format": "biome check --write",
     "test": "renovate-config-validator ./default.json --strict"


### PR DESCRIPTION
CIの `actions/setup-node` が `node-version-file: "package.json"` を参照しているため、`volta.node` フィールドでNodeバージョンを固定する。

Node.js 26系で7日以内にリリースされた最新版である [v26.1.0](https://nodejs.org/dist/v26.1.0/) (2026-05-06) を指定。Renovateの `rangeStrategy: "pin"` および `minimumReleaseAge: "7 days"` により、今後の更新もこのフィールドで追随できる。