### PR TITLE
Update Renovate config: use best-practices and refine digest pinning

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,15 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "config:best-practices",
     ":label(renovate)",
     ":reviewer(k35o)",
     ":timezone(Asia/Tokyo)",
     ":pinAllExceptPeerDependencies",
     "group:allNonMajor",
     "schedule:automergeWeekends",
-    "docker:pinDigests",
-    "helpers:pinGitHubActionDigests",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   "schedule": [


### PR DESCRIPTION
## Summary
Updated the Renovate configuration to use a more modern and comprehensive preset while streamlining the digest pinning strategy for better maintainability.

## Key Changes
- Changed base preset from `config:recommended` to `config:best-practices` for improved default configurations
- Removed `docker:pinDigests` preset (functionality now covered by best-practices preset)
- Removed `helpers:pinGitHubActionDigests` preset in favor of the more specific `helpers:pinGitHubActionDigestsToSemver` preset

## Details
The `config:best-practices` preset provides a more opinionated and comprehensive set of defaults compared to `config:recommended`. The removal of the redundant digest pinning presets consolidates the configuration while maintaining the desired behavior through the retained `helpers:pinGitHubActionDigestsToSemver` preset, which pins GitHub Actions to semantic versioning.

https://claude.ai/code/session_011zzuhgnDt8pq93PMWwe4MM