### PR TITLE
chore: PR頻度を上げ、vulnerability alertsを復活

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,13 +7,16 @@
     ":timezone(Asia/Tokyo)",
     ":pinAllExceptPeerDependencies",
     "group:allNonMajor",
-    "schedule:automergeWeekends",
     "helpers:pinGitHubActionDigestsToSemver"
-  ],
-  "schedule": [
-    "every weekend"
   ],
   "rangeStrategy": "pin",
   "minimumReleaseAge": "7 days",
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": [
+      "security"
+    ]
+  },
+  "osvVulnerabilityAlerts": true,
   "internalChecksFilter": "strict"
 }


### PR DESCRIPTION
## 概要

通常更新のスケジュール制限を撤廃して常時PR/automergeに切り替え、過去にOOMで外していた `vulnerabilityAlerts` / `osvVulnerabilityAlerts` を復活させる。

## 動機

- Mend経由で動かしているのでCIコストは気にならず、週末バッチよりも頻繁に更新を取り入れたい。
- セキュリティ修正は `vulnerabilityAlerts` のデフォルトで `schedule` / `minimumReleaseAge` をバイパスして即時PRになるため、これを有効化すればCVEを早く取り込める。

## 変更内容

- `default.json`
  - `schedule: ["every weekend"]` を削除（= `at any time`）
  - `extends` から `schedule:automergeWeekends` を削除（automergeも常時実行）
  - `vulnerabilityAlerts: { enabled: true, labels: ["security"] }` を復活
  - `osvVulnerabilityAlerts: true` を復活

## 気をつけるポイント

- `osvVulnerabilityAlerts` は manager 実行時にOSV DBを引きに行く都合でメモリを食う。過去に [2d5df39](https://github.com/k35o/renovate-config/commit/2d5df39) でOOM理由でoffにしている。Mend環境では問題ない想定だが、もし再発したら `osvVulnerabilityAlerts` のみ外し、Dependabot連携の `vulnerabilityAlerts` だけで運用する。
- `minimumReleaseAge: 7 days` は通常更新には引き続き効くが、`vulnerabilityAlerts` デフォルトの `minimumReleaseAge: null` により脆弱性修正はバイパスされる。