### PR TITLE
chore(config): npm の minimumReleaseAge を 7 days に上書き

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,5 +18,11 @@
     ]
   },
   "osvVulnerabilityAlerts": true,
-  "internalChecksFilter": "strict"
+  "internalChecksFilter": "strict",
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "7 days"
+    }
+  ]
 }

--- a/default.json
+++ b/default.json
@@ -21,7 +21,9 @@
   "internalChecksFilter": "strict",
   "packageRules": [
     {
-      "matchDatasources": ["npm"],
+      "matchDatasources": [
+        "npm"
+      ],
       "minimumReleaseAge": "7 days"
     }
   ]


### PR DESCRIPTION
## なぜ

`config:best-practices` は内部で [`security:minimumReleaseAgeNpm`](https://github.com/renovatebot/renovate/blob/main/lib/config/presets/internal/security.preset.ts) を extend しており、そこで以下の packageRule が定義されている。

```js
{
  matchDatasources: ['npm'],
  minimumReleaseAge: '3 days',
  internalChecksFilter: 'strict',
}
```

Renovate の設定マージでは **packageRules がトップレベル設定を上書きする** ため、root に書いている `minimumReleaseAge: "7 days"` は npm datasource のパッケージには効かず、実効値が 3 days になっていた。

実例として [k35o/dotfiles#20](https://github.com/k35o/dotfiles/pull/20) では pnpm 11.1.3 / @openai/codex 0.131.0 (リリースから約 3 日) が PR に含まれた一方、`github-releases` / `node-version` datasource の chezmoi・node などは root の 7 days ルールで保留されていた。

## なに

npm datasource にも 7 days を適用する packageRule を追加し、preset の 3 days を上書き。

## レビュー観点

- npm 系の更新が出るまで 7 日待つようになる（意図通り）
- 非 npm datasource は既に root の `minimumReleaseAge: "7 days"` で 7 日待っており挙動変わらず
- `internalChecksFilter: "strict"` も root に設定済みなので strict のまま

## Test plan

- [ ] この設定を extend している repo (k35o/dotfiles 等) で、次回 Renovate 実行時に 7 日未満の npm パッケージが PR に含まれないことを確認