### PR TITLE
feat: minor/patch を CI 通過後に自動マージする

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,7 +7,8 @@
     ":timezone(Asia/Tokyo)",
     ":pinAllExceptPeerDependencies",
     "group:allNonMajor",
-    "helpers:pinGitHubActionDigestsToSemver"
+    "helpers:pinGitHubActionDigestsToSemver",
+    ":automergeMinor"
   ],
   "rangeStrategy": "pin",
   "minimumReleaseAge": "7 days",

--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>k35o/renovate-config",
-    "customManagers:biomeVersions",
-    ":automergeMinor"
+    "customManagers:biomeVersions"
   ],
   "prConcurrentLimit": 10
 }


### PR DESCRIPTION
## 概要

共有 Renovate 設定 `default.json` に `:automergeMinor` を追加し、`github>k35o/renovate-config` を extends する全リポジトリで **minor / patch アップデートを CI 通過後に自動マージ**できるようにする。

## 動機

minor / patch は破壊的変更が入りにくく、毎回手動でマージするのは手間。CI が通れば人手を介さずマージしてしまってよい、という運用に寄せる。

## 詳細

- `default.json` の extends に `:automergeMinor` を追加（minor + patch を対象に automerge）。
- `renovate.json` 側で重複していた `:automergeMinor` を削除。共有 `default.json` から効くようになるため不要。
- major は対象外のまま（引き続き手動レビュー）。
- `minimumReleaseAge: 7 days` によるリリース直後回避バッファは維持。

## 気をつけるポイント / 影響範囲

- これは**共有設定**なので、マージ後は `github>k35o/renovate-config` を使う全 public リポジトリに波及する。
- 自動マージが「CI 通過後」で実際に待つには、各リポジトリ側で **required status checks（ブランチ保護ルールセット）** と **承認要件の調整**が別途必要。本リポジトリ（renovate-config）のルールセットは対応済み（`ci` を必須化・承認0）。他リポジトリは順次対応予定。

## テスト

- `pnpm test`（`renovate-config-validator --strict`）通過。
- `pnpm format`（biome）差分なし。